### PR TITLE
Changing from Docker to Docker CE

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ For mac:          https://docs.docker.com/docker-for-mac/install/#download-docke
 ```
 For CentOS/RHEL/Fedora linux host:
 ```
-yum install docker
+Setup the repo:
+sudo yum-config-manager \
+    --add-repo \
+    https://download.docker.com/linux/centos/docker-ce.repo
+Install Docker CE:
+yum install docker-ce
 ```
 For Ubuntu linux host:
 ```


### PR DESCRIPTION
 It fails to start lighttpd and the following error appears:
  echo 'ERROR: failed to obtain IP of local RPM repository'
ERROR: failed to obtain IP of local RPM repository
  docker ps -a
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                        PORTS                    NAMES
c9eac7fc8bb4        registry:2          "/entrypoint.sh /e..."   31 seconds ago      Up 30 seconds                 0.0.0.0:6666->5000/tcp   tf-dev-env-registry
3baf55a977ec        sebp/lighttpd       "start.sh"               36 seconds ago      Exited (255) 35 seconds ago                            tf-dev-env-rpm-repo
  docker logs tf-dev-env-rpm-repo
chmod: /dev/pts/0: No such file or directory
2019-08-14 06:45:50: (server.c.748) opening errorlog '/dev/pts/0' failed: Permission denied
2019-08-14 06:45:50: (server.c.1518) Opening errorlog failed. Going down.
  exit 1
