### PR TITLE
Fix startup.sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cd tf-dev-env
 
 ### 3. Execute script to start 3 containers
 ```
-sudo ./startup.sh
+sudo -E bash -c ./startup.sh
 ```
 
 **Note:** This command runs container `opencontrailnightly/developer-sandbox-centos:master` from [opencontrailnightly docker hub](https://hub.docker.com/r/opencontrailnightly/developer-sandbox/) by

--- a/startup.sh
+++ b/startup.sh
@@ -214,7 +214,7 @@ if [ ! -e ${contrail_dir}/repo ] ; then
   echo "INFO: Download repo tool"
   curl -s https://storage.googleapis.com/git-repo-downloads/repo > ${contrail_dir}/repo
   chmod a+x ${contrail_dir}/repo
-  ${contrail_dir}/repo init --no-clone-bundle -q -u https://github.com/Juniper/contrail-vnc -b $VNC_BRANCH
+  (cd ${contrail_dir} && ./repo init --no-clone-bundle -q -u https://github.com/Juniper/contrail-vnc -b $VNC_BRANCH)
 fi  
 
 if ! is_created "tf-developer-sandbox"; then
@@ -292,4 +292,4 @@ fi
 
 echo
 echo '[READY]'
-test "$own_vm" -eq 0 && echo "You can now connect to the sandbox container by using: $ docker attach tf-developer-sandbox"
+echo "You can now connect to the sandbox container by using: $ docker attach tf-developer-sandbox"


### PR DESCRIPTION
repo init needs to be executed from contrail_dir
removing undefined own_vm variable

fixing README to accomodate passing environment variables

Signed-off-by: Prabhjot Singh Sethi <prabhjot@atsgen.com>